### PR TITLE
Typos, rephrasing, add curl API call examples.

### DIFF
--- a/src/TUTORIAL.md
+++ b/src/TUTORIAL.md
@@ -1016,7 +1016,26 @@ This is similar to what we've already done in the `accounts.js` handler, but mor
 
 ### Preventing Referred Records Deletion
 
-Another situation we must gracefully prevent is deleting _Product_ and _Account_ records when _Order_ records exist for them. Let's add the appropriate hooks to our `account.js` handler:
+Another situation we must gracefully prevent is deleting _Product_ and _Account_ records when _Order_ records exist for them. 
+
+Currently, (assuming a product with ID 1 has been purchased by a customer with an account which also has an ID of 1)... 
+
+...if you try to delete a product with ID 1:
+
+```shell
+$ curl -v -X DELETE http://localhost:3001/products/1
+```
+...or delete an account with ID 1
+
+```shell
+$ curl -v -X DELETE http://localhost:3001/accounts/1
+```
+
+...the web-service will return another [HTTP 500](https://tools.ietf.org/html/rfc7231#section-6.6.1) error, with an unhelpful error message: "Internal server error".  
+
+
+
+Instead, the web-service should return a [HTTP 400](https://tools.ietf.org/html/rfc7231#section-6.5.1) response with a helpful error message, so let's add the appropriate hooks to our `account.js` handler:
 
 ```javascript
 ...
@@ -1068,7 +1087,7 @@ module.exports = {
 
 Note how we extract the addressed record (_Account_ or _Product_) ID from the call URI. When we used `ws.addEntpoint()` function in `server.js` to define the `/accounts/{accountId}` and `/products/{productId}` endpoints, we used capturing groups in the URI regular expressions. Those groups translate to the `uriParams` array on the API call object available to the handlers via the `call` property of the transaction context. The API call object is what the low-level [x2node-ws](https://github.com/boylesoftware/x2node-ws) module operates with and it exposes many useful things to the handlers. See its full description in the [Service Call](https://github.com/boylesoftware/x2node-ws#service-call) section of the manual as well as its full [API reference](https://boylesoftware.github.io/x2node-api-reference/module-x2node-ws-ServiceCall.html).
 
-And you also can see that in this case we don't need to call `txCtx.refToId()` function to convert the reference to the ID as we are getting the ID straight from the URI.
+You should also take note that in this case, we don't need to call the `txCtx.refToId()` function in order to convert the reference to the ID, as we are getting the ID straight from the URI.
 
 ### Backend Field Value Calculation
 

--- a/src/TUTORIAL.md
+++ b/src/TUTORIAL.md
@@ -634,7 +634,7 @@ Now we can try to update our product record. To do that, we are going to send a 
 ]
 ```
 
-And send it to the web-service: *(Note: if using the X2 RESTful API Tester you will need to enter *`application/json-patch+json`* into the 'Content Type' form field)*.
+And send it to the web-service: *(Note: if using the X2 RESTful API Tester make sure `application/json-patch+json` is present in the 'Content Type' form field.)*.
 
 ```shell
 $ curl -v -X PATCH -H "Content-Type: application/json-patch+json" --data-binary @patch-product.json http://localhost:3001/products/1
@@ -1210,7 +1210,7 @@ We can test this by creating a new patch document which complies with the [JSON 
 ```
 Now, if we send a `PATCH` request to the `/accounts/3` endpoint (assuming we intend to update an account with an ID of 3)
 
-_Note: if using the X2 RESTful API Tester you will need to enter application/merge-patch+json into the 'Content Type' form field.)_:
+_Note: if using the X2 RESTful API Tester make sure `application/merge-patch+json` is present in the 'Content Type' form field.)_:
 
 ```shell
 $ curl -v -X PATCH -H "Content-Type: application/merge-patch+json" --data-binary @json-merge-patch-account.json http://localhost:3001/accounts/3
@@ -1273,7 +1273,7 @@ Now we support both:
 
 [JSON Patch](https://tools.ietf.org/html/rfc6902) format
 
-_Note: if using the X2 RESTful API Tester you will need to enter application/json-patch+json into the 'Content Type' form field.)_:
+_Note: if using the X2 RESTful API Tester make sure `application/json-patch+json` is present in the 'Content Type' form field.)_:
 
 Create a new patch document which complies with the [JSON Patch](https://tools.ietf.org/html/rfc6902) format standards called `json-patch-account.json`, containing the JSON below:
 
@@ -1299,7 +1299,7 @@ $ curl -v -X PATCH -H "Content-Type: application/json-patch+json" --data-binary 
 
 [JSON Merge Patch](https://tools.ietf.org/html/rfc7396) format
 
-_Note: if using the X2 RESTful API Tester you will need to enter application/merge-patch+json into the 'Content Type' form field.)_:
+_Note: if using the X2 RESTful API Tester make sure `application/merge-patch+json` is present in the 'Content Type' form field.)_:
 
 ```shell
 $ curl -v -X PATCH -H "Content-Type: application/merge-patch+json" --data-binary @json-merge-patch-account.json http://localhost:3001/accounts/3

--- a/src/TUTORIAL.md
+++ b/src/TUTORIAL.md
@@ -749,12 +749,36 @@ ws.createApplication()
     ...
 ```
 
-We recommend keeping each endpoint handler extension in its own file under the project folder: `lib/handlers`. *Note: endpoint handler extension file names differentiated between collections (ending with 's') and individual resources (not ending with 's').* For now, you can create 6 empty handler extensions as specified above, and we will fill them in as we progress through the tutorial. For example, an empty handler extension for products `lib/handlers/products.js`, would be:
+We recommend keeping each endpoint handler extension in its own file under the project folder: `lib/handlers`. *Note: endpoint handler extension file names differentiated between collections (ending with 's') and individual resources (not ending with 's').* For now, you can create 6 empty handler extensions as specified above, and we will fill them in as we progress through the tutorial. For example, an empty handler extension for products: `lib/handlers/products.js`, would be:
 
 ```javascript
 'use strict';
 
 module.exports = {};
+```
+
+At this stage, we should have the following project structure:
+
+```
+x2tutorial/
++--lib/
+|  +--handlers/
+|     +--account.js
+|     +--accounts.js
+|     +--order.js
+|     +--orders.js
+|     +--product.js
+|     +--products.js
+|  +--record-type-defs.js
++--misc/
+|  +--schema/
+|     +--create-schema-mysql.sql
++--node_modules/
+|  +--...
++--.env
++--package-lock.json
++--package.json
++--server.js
 ```
 
 Now, let's have a look at our problems.

--- a/src/TUTORIAL.md
+++ b/src/TUTORIAL.md
@@ -1040,24 +1040,18 @@ This is similar to what we've already done in the `accounts.js` handler, but mor
 
 ### Preventing Referred Records Deletion
 
-Another situation we must gracefully prevent is deleting _Product_ and _Account_ records when _Order_ records exist for them. 
-
-Currently, (assuming a product with ID 1 has been purchased by a customer with an account which also has an ID of 1)... 
-
-...if you try to delete a product with ID 1:
+Another situation we must gracefully prevent is deleting _Product_ and _Account_ records when _Order_ records exist for them. Currently, (assuming a product with ID 1 has been purchased by a customer with an account which also has an ID of 1) if you try to delete a product with ID 1:
 
 ```shell
 $ curl -v -X DELETE http://localhost:3001/products/1
 ```
-...or delete an account with ID 1
+or delete an account with ID 1
 
 ```shell
 $ curl -v -X DELETE http://localhost:3001/accounts/1
 ```
 
-...the web-service will return another [HTTP 500](https://tools.ietf.org/html/rfc7231#section-6.6.1) error, with an unhelpful error message: "Internal server error".  
-
-
+the web-service will return another [HTTP 500](https://tools.ietf.org/html/rfc7231#section-6.6.1) error, with an unhelpful error message: "Internal server error".  
 
 Instead, the web-service should return a [HTTP 400](https://tools.ietf.org/html/rfc7231#section-6.5.1) response with a helpful error message, so let's add the appropriate hooks to our `account.js` handler:
 
@@ -1119,7 +1113,7 @@ When we work with our _Account_ records, we have to provide a `passwordDigest` v
 
 Therefore, when the client creates and updates _Account_ records, we'd rather have it send the account password in plain text and have our web-service calculate the digest.
 
-**Important: You must be able to ensure clients may only send passwords in plain text, if they are using a secure encrypted connection with the server.**
+**Important: Please make sure that in a production environment sensitive information such as plain text passwords are exchanged between the client and the web-service over a secure connection (SSL).**
 
 First, let's see how this can be done for a call to create a new account.
 
@@ -1158,13 +1152,13 @@ Now, if we create a new _Account_ record, by replacing the contents of the `new-
   "password": "hoistthesales!"
 }
 ```
-And `POST` it to the web-service;
+and `POST` it to the web-service;
 
 ```shell
 $ curl -v -H "Content-Type: application/json" --data-binary @new-account.json http://localhost:3001/accounts
 ```
 
-...the record created will be something like this:
+the record created will be something like this:
 
 ```json
 {
@@ -1222,7 +1216,7 @@ _Note: if using the X2 RESTful API Tester you will need to enter application/mer
 $ curl -v -X PATCH -H "Content-Type: application/merge-patch+json" --data-binary @json-merge-patch-account.json http://localhost:3001/accounts/3
 ```
 
-...we will get back our updated record:
+we will get back our updated record:
 
 ```json
 {

--- a/src/TUTORIAL.md
+++ b/src/TUTORIAL.md
@@ -1206,7 +1206,7 @@ module.exports = {
 };
 ```
 
-We can test this by creating a new patch document called `patch-account.json`, containing the JSON below:
+We can test this by creating a new patch document which complies with the [JSON Merge Patch](https://tools.ietf.org/html/rfc7396) format standards called `json-merge-patch-account.json`, containing the JSON below:
 
 ```json
 {
@@ -1219,7 +1219,7 @@ Now, if we send a `PATCH` request to the `/accounts/3` endpoint (assuming we int
 _Note: if using the X2 RESTful API Tester you will need to enter application/merge-patch+json into the 'Content Type' form field.)_:
 
 ```shell
-$ curl -v -X PATCH -H "Content-Type: application/merge-patch+json" --data-binary @patch-account.json http://localhost:3001/accounts/3
+$ curl -v -X PATCH -H "Content-Type: application/merge-patch+json" --data-binary @json-merge-patch-account.json http://localhost:3001/accounts/3
 ```
 
 ...we will get back our updated record:
@@ -1281,8 +1281,26 @@ Now we support both:
 
 _Note: if using the X2 RESTful API Tester you will need to enter application/json-patch+json into the 'Content Type' form field.)_:
 
+Create a new patch document which complies with the [JSON Patch](https://tools.ietf.org/html/rfc6902) format standards called `json-patch-account.json`, containing the JSON below:
+
+```json
+[
+  {
+    "op": "replace",
+    "path": "/firstName",
+    "value": "William"
+  },
+  {
+    "op": "replace",
+    "path": "/password",
+    "value": "piecesofeight!"
+  }
+]
+
+```
+
 ```shell
-$ curl -v -X PATCH -H "Content-Type: application/json-patch+json" --data-binary @patch-account.json http://localhost:3001/accounts/3
+$ curl -v -X PATCH -H "Content-Type: application/json-patch+json" --data-binary @json-patch-account.json http://localhost:3001/accounts/3
 ```
 
 [JSON Merge Patch](https://tools.ietf.org/html/rfc7396) format
@@ -1290,7 +1308,7 @@ $ curl -v -X PATCH -H "Content-Type: application/json-patch+json" --data-binary 
 _Note: if using the X2 RESTful API Tester you will need to enter application/merge-patch+json into the 'Content Type' form field.)_:
 
 ```shell
-$ curl -v -X PATCH -H "Content-Type: application/merge-patch+json" --data-binary @patch-account.json http://localhost:3001/accounts/3
+$ curl -v -X PATCH -H "Content-Type: application/merge-patch+json" --data-binary @json-merge-patch-account.json http://localhost:3001/accounts/3
 ```
 
 ### Backend Operations


### PR DESCRIPTION
Note the disclaimer in the 'Backend Field Value Calculation' RE: sending passwords in the clear;

**Important: You must be able to ensure clients may only send passwords in plain text, if they are using a secure encrypted connection with the server.**

Not sure if you want to amend or remove it @levahim ?